### PR TITLE
Add arrow-key next/previous navigation to side sheets

### DIFF
--- a/src/Components/AnimationsGuide.jsx
+++ b/src/Components/AnimationsGuide.jsx
@@ -1,5 +1,6 @@
 import AnimationsData from "../Data/AnimationsData.json";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
 import useSEO from "./Hooks/useSEO";
 import { 
   LuMove, 
@@ -46,6 +47,11 @@ const AnimationSubCard = ({ type, onClick }) => (
   </button>
 );
 
+AnimationSubCard.propTypes = {
+  type: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
 const AnimationsGuide = () => {
   const [selectedAnim, setSelectedAnim] = useState(null);
 
@@ -59,6 +65,16 @@ const AnimationsGuide = () => {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: "instant" });
   }, []);
+
+  const flattenedItems = useMemo(() =>
+    AnimationsData.flatMap((category) =>
+      category.SubAnimations.map((item) => ({ ...item, category: category.Category }))
+    ),
+  []);
+
+  const selectedItemIndex = useMemo(() =>
+    flattenedItems.findIndex((item) => item.Type === selectedAnim?.Type && item.category === selectedAnim?.category),
+  [flattenedItems, selectedAnim]);
 
   useEffect(() => {
     const lockScroll = () => {
@@ -75,8 +91,28 @@ const AnimationsGuide = () => {
     } else {
       unlockScroll();
     }
-    return () => unlockScroll();
-  }, [selectedAnim]);
+
+    const handleKeydown = (e) => {
+      if (e.key === "Escape") {
+        setSelectedAnim(null);
+      }
+      if (e.key === "ArrowRight" && selectedItemIndex >= 0) {
+        setSelectedAnim(flattenedItems[(selectedItemIndex + 1) % flattenedItems.length]);
+      }
+      if (e.key === "ArrowLeft" && selectedItemIndex >= 0) {
+        setSelectedAnim(flattenedItems[(selectedItemIndex - 1 + flattenedItems.length) % flattenedItems.length]);
+      }
+    };
+
+    if (selectedAnim) {
+      window.addEventListener("keydown", handleKeydown);
+    }
+
+    return () => {
+      unlockScroll();
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [flattenedItems, selectedItemIndex, selectedAnim]);
 
   return (
     <div 

--- a/src/Components/DesignStyles.jsx
+++ b/src/Components/DesignStyles.jsx
@@ -116,6 +116,27 @@ const DesignStyles = () => {
 
   const closeSheet = useCallback(() => setSelectedStyle(null), []);
 
+  const flattenedStyles = useMemo(
+    () => filteredData.flatMap((category) => category.styles),
+    [filteredData]
+  );
+
+  const selectedStyleIndex = useMemo(
+    () => flattenedStyles.findIndex((item) => item.style === selectedStyle?.style),
+    [flattenedStyles, selectedStyle]
+  );
+
+  const selectNextStyle = useCallback(() => {
+    if (!flattenedStyles.length || selectedStyleIndex < 0) return;
+    setSelectedStyle(flattenedStyles[(selectedStyleIndex + 1) % flattenedStyles.length]);
+  }, [flattenedStyles, selectedStyleIndex]);
+
+  const selectPrevStyle = useCallback(() => {
+    if (!flattenedStyles.length || selectedStyleIndex < 0) return;
+    setSelectedStyle(flattenedStyles[(selectedStyleIndex - 1 + flattenedStyles.length) % flattenedStyles.length]);
+  }, [flattenedStyles, selectedStyleIndex]);
+
+
   return (
     <div className="relative max-w-full min-h-screen overflow-x-hidden bg-base-100">
       {/* Main Content Wrapper (Optimized for composite-only 60fps performance) */}
@@ -190,7 +211,7 @@ const DesignStyles = () => {
       </div>
 
       {/* Side Sheet */}
-      <StyleSheet style={selectedStyle} onClose={closeSheet} />
+      <StyleSheet style={selectedStyle} onClose={closeSheet} onNext={selectNextStyle} onPrev={selectPrevStyle} />
 
       {/* Filter Modal */}
       <StyleFilterModal 

--- a/src/Components/DesignStyles/StyleSheet.jsx
+++ b/src/Components/DesignStyles/StyleSheet.jsx
@@ -49,7 +49,7 @@ SectionCard.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const StyleSheet = ({ style, onClose }) => {
+const StyleSheet = ({ style, onClose, onNext, onPrev }) => {
   useEffect(() => {
     const lockScroll = () => {
       document.documentElement.style.overflow = "hidden";
@@ -66,19 +66,21 @@ const StyleSheet = ({ style, onClose }) => {
       unlockScroll();
     }
 
-    const handleEsc = (e) => {
+    const handleKeydown = (e) => {
       if (e.key === "Escape") onClose();
+      if (e.key === "ArrowRight") onNext?.();
+      if (e.key === "ArrowLeft") onPrev?.();
     };
 
     if (style) {
-      window.addEventListener("keydown", handleEsc);
+      window.addEventListener("keydown", handleKeydown);
     }
 
     return () => {
       unlockScroll();
-      window.removeEventListener("keydown", handleEsc);
+      window.removeEventListener("keydown", handleKeydown);
     };
-  }, [style, onClose]);
+  }, [style, onClose, onNext, onPrev]);
 
   if (!style) return null;
 
@@ -218,6 +220,8 @@ const StyleSheet = ({ style, onClose }) => {
 StyleSheet.propTypes = {
   style: PropTypes.object,
   onClose: PropTypes.func.isRequired,
+  onNext: PropTypes.func,
+  onPrev: PropTypes.func,
 };
 
 export default StyleSheet;

--- a/src/Components/MotionDesign.jsx
+++ b/src/Components/MotionDesign.jsx
@@ -1,5 +1,5 @@
 import MotionDesignData from "../Data/MotionDesignData.json";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import PropTypes from "prop-types";
 import useSEO from "./Hooks/useSEO";
@@ -62,6 +62,16 @@ const MotionDesign = () => {
     window.scrollTo({ top: 0, behavior: "instant" });
   }, []);
 
+  const flattenedItems = useMemo(() =>
+    MotionDesignData.flatMap((category) =>
+      category.SubPrinciples.map((item) => ({ ...item, category: category.Category }))
+    ),
+  []);
+
+  const selectedItemIndex = useMemo(() =>
+    flattenedItems.findIndex((item) => item.Type === selectedPrinciple?.Type && item.category === selectedPrinciple?.category),
+  [flattenedItems, selectedPrinciple]);
+
   useEffect(() => {
     const lockScroll = () => {
       document.documentElement.style.overflow = "hidden";
@@ -77,8 +87,28 @@ const MotionDesign = () => {
     } else {
       unlockScroll();
     }
-    return () => unlockScroll();
-  }, [selectedPrinciple]);
+
+    const handleKeydown = (e) => {
+      if (e.key === "Escape") {
+        setSelectedPrinciple(null);
+      }
+      if (e.key === "ArrowRight" && selectedItemIndex >= 0) {
+        setSelectedPrinciple(flattenedItems[(selectedItemIndex + 1) % flattenedItems.length]);
+      }
+      if (e.key === "ArrowLeft" && selectedItemIndex >= 0) {
+        setSelectedPrinciple(flattenedItems[(selectedItemIndex - 1 + flattenedItems.length) % flattenedItems.length]);
+      }
+    };
+
+    if (selectedPrinciple) {
+      window.addEventListener("keydown", handleKeydown);
+    }
+
+    return () => {
+      unlockScroll();
+      window.removeEventListener("keydown", handleKeydown);
+    };
+  }, [flattenedItems, selectedItemIndex, selectedPrinciple]);
 
   return (
     <div className="relative min-h-screen bg-base-100 max-w-full overflow-x-hidden">

--- a/src/Components/VibeExplorer.jsx
+++ b/src/Components/VibeExplorer.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, memo } from "react";
+import { useState, useMemo, useEffect, memo, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { LuFilter, LuRotateCcw, LuSearch, LuInbox } from "react-icons/lu";
 import vibeData from "../Data/vibeData.json";
@@ -46,6 +46,21 @@ const VibeExplorer = () => {
       return fitB - fitA;
     });
   }, [selectedMood, searchQuery]);
+
+  const selectedGenreIndex = useMemo(
+    () => filteredGenres.findIndex((genre) => genre.id === selectedGenre?.id),
+    [filteredGenres, selectedGenre]
+  );
+
+  const selectNextGenre = useCallback(() => {
+    if (!filteredGenres.length || selectedGenreIndex < 0) return;
+    setSelectedGenre(filteredGenres[(selectedGenreIndex + 1) % filteredGenres.length]);
+  }, [filteredGenres, selectedGenreIndex]);
+
+  const selectPrevGenre = useCallback(() => {
+    if (!filteredGenres.length || selectedGenreIndex < 0) return;
+    setSelectedGenre(filteredGenres[(selectedGenreIndex - 1 + filteredGenres.length) % filteredGenres.length]);
+  }, [filteredGenres, selectedGenreIndex]);
 
   const activeMood = useMemo(() => 
     vibeData.moods.find(m => m.id === selectedMood), 
@@ -182,6 +197,8 @@ const VibeExplorer = () => {
           <GenreSheet 
             genre={selectedGenre} 
             onClose={() => setSelectedGenre(null)} 
+            onNext={selectNextGenre}
+            onPrev={selectPrevGenre}
           />
         )}
       </AnimatePresence>

--- a/src/Components/VibeExplorer/GenreSheet.jsx
+++ b/src/Components/VibeExplorer/GenreSheet.jsx
@@ -47,7 +47,7 @@ const SectionHeader = ({ icon: Icon, title }) => (
   </div>
 );
 
-const GenreSheet = ({ genre, onClose }) => {
+const GenreSheet = ({ genre, onClose, onNext, onPrev }) => {
   useEffect(() => {
     const lockScroll = () => {
       document.documentElement.style.overflow = "hidden";
@@ -61,16 +61,18 @@ const GenreSheet = ({ genre, onClose }) => {
     if (genre) lockScroll();
     else unlockScroll();
 
-    const handleEsc = (e) => {
+    const handleKeydown = (e) => {
       if (e.key === "Escape") onClose();
+      if (e.key === "ArrowRight") onNext?.();
+      if (e.key === "ArrowLeft") onPrev?.();
     };
 
-    if (genre) window.addEventListener("keydown", handleEsc);
+    if (genre) window.addEventListener("keydown", handleKeydown);
     return () => {
       unlockScroll();
-      window.removeEventListener("keydown", handleEsc);
+      window.removeEventListener("keydown", handleKeydown);
     };
-  }, [genre, onClose]);
+  }, [genre, onClose, onNext, onPrev]);
 
   if (!genre) return null;
 
@@ -211,6 +213,8 @@ GenreSheet.propTypes = {
     note: PropTypes.string.isRequired,
   }),
   onClose: PropTypes.func.isRequired,
+  onNext: PropTypes.func,
+  onPrev: PropTypes.func,
 };
 
 ComparisonRow.propTypes = {

--- a/src/Components/common/GuideLayout.jsx
+++ b/src/Components/common/GuideLayout.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import useSEO from "../Hooks/useSEO";
 import {
@@ -42,6 +42,14 @@ const GuideLayout = ({
 }) => {
     const [selectedPrinciple, setSelectedPrinciple] = useState(null);
 
+    const flattenedPrinciples = useMemo(() =>
+        data.flatMap((category) => (category.Principles || category.Skills || []).map((item) => ({ ...item, category: category.Category }))),
+    [data]);
+
+    const selectedPrincipleIndex = useMemo(() =>
+        flattenedPrinciples.findIndex((item) => item.Title === selectedPrinciple?.Title && item.category === selectedPrinciple?.category),
+    [flattenedPrinciples, selectedPrinciple]);
+
     useSEO(seoConfig);
 
     useEffect(() => {
@@ -64,19 +72,25 @@ const GuideLayout = ({
             unlockScroll();
         }
 
-        const handleEsc = (e) => {
+        const handleKeydown = (e) => {
             if (e.key === "Escape") setSelectedPrinciple(null);
+            if (e.key === "ArrowRight" && selectedPrincipleIndex >= 0) {
+                setSelectedPrinciple(flattenedPrinciples[(selectedPrincipleIndex + 1) % flattenedPrinciples.length]);
+            }
+            if (e.key === "ArrowLeft" && selectedPrincipleIndex >= 0) {
+                setSelectedPrinciple(flattenedPrinciples[(selectedPrincipleIndex - 1 + flattenedPrinciples.length) % flattenedPrinciples.length]);
+            }
         };
 
         if (selectedPrinciple) {
-            window.addEventListener("keydown", handleEsc);
+            window.addEventListener("keydown", handleKeydown);
         }
 
         return () => {
             unlockScroll();
-            window.removeEventListener("keydown", handleEsc);
+            window.removeEventListener("keydown", handleKeydown);
         };
-    }, [selectedPrinciple]);
+    }, [flattenedPrinciples, selectedPrinciple, selectedPrincipleIndex]);
 
     // Icon for the side sheet
     const SelectedCategoryIcon = selectedPrinciple ? (categoryIcons[selectedPrinciple.category] || DefaultIcon) : null;


### PR DESCRIPTION
### Motivation
- Make sheet/drawer experiences navigable with keyboard arrows so users can move to the next/previous item (left/right) in contexts where a side sheet is open, while keeping Escape to close the sheet.

### Description
- Wire `onNext` / `onPrev` handlers into sheet components and listen for `ArrowRight` and `ArrowLeft` alongside `Escape` in `StyleSheet` and `GenreSheet` by adding keydown handlers and prop validation. (files: `src/Components/DesignStyles/StyleSheet.jsx`, `src/Components/VibeExplorer/GenreSheet.jsx`).
- Add parent-level selection logic to compute flattened lists and current indices and provide wrap-around next/prev callbacks for the open sheet in `DesignStyles` and `VibeExplorer`. (files: `src/Components/DesignStyles.jsx`, `src/Components/VibeExplorer.jsx`).
- Extend the reusable `GuideLayout` to flatten its items and support arrow-key traversal between principles when a sheet is open so pages using it inherit the behavior. (file: `src/Components/common/GuideLayout.jsx`).
- Add equivalent flattening + arrow-key navigation for page-local sheet implementations in `AnimationsGuide` and `MotionDesign`. (files: `src/Components/AnimationsGuide.jsx`, `src/Components/MotionDesign.jsx`).
- Add missing `PropTypes` for `AnimationSubCard` to satisfy lint rules. (file: `src/Components/AnimationsGuide.jsx`).

### Testing
- Ran targeted linter across modified files with `npx eslint src/Components/DesignStyles.jsx src/Components/DesignStyles/StyleSheet.jsx src/Components/VibeExplorer.jsx src/Components/VibeExplorer/GenreSheet.jsx src/Components/common/GuideLayout.jsx src/Components/AnimationsGuide.jsx src/Components/MotionDesign.jsx`, which passed for the edited files. 
- Ran project lint `npm run -s lint`, which still fails due to unrelated pre-existing lint issues elsewhere in the repo (these errors are not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f306ae6bcc832aad40aa69093d80fa)