### PR TITLE
Add SEO metadata & sitemap to prerender, support framework slug routes, and guard localStorage

### DIFF
--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -16,34 +16,239 @@ if (typeof render !== 'function') {
   throw new Error('Expected entry-server to export a render() function')
 }
 
-const routesToPrerender = [
+const frameworkLangs = [
+  'HTML',
+  'CSS',
+  'JavaScript',
+  'TypeScript',
+  'Python',
+  'Java',
+  'PHP',
+  'Go',
+  'Rust',
+  'Ruby',
+  'Swift',
+  'Kotlin',
+  'C++',
+  'C#',
+  'R',
+  'Dart',
+  'Scala',
+  'Lua',
+  'Elixir',
+]
+
+const baseRoutes = [
   '/',
   '/Frameworks',
   '/TimeLine',
   '/ml-roadmap',
+  '/ai-roadmap',
+  '/swe-roadmap',
   '/developer-essential-skills',
+  '/system-design',
+  '/design-patterns',
+  '/devops',
+  '/project-checklist',
+  '/design-principles',
+  '/design-styles',
+  '/motion-design',
+  '/animations-guide',
+  '/civic-sense',
+  '/social-intelligence',
+  '/vibe-explorer',
 ]
 
-for (const url of routesToPrerender) {
-  const appHtml = await render(url)
-  const hydratedHtml = templateHtml.replace(
-    '<div id="root"></div>',
-    `<div id="root">${appHtml}</div>`,
+const frameworkLangRoutes = frameworkLangs.map(
+  (lang) => `/Frameworks?lang=${encodeURIComponent(lang)}`,
+)
+
+const routesToPrerender = [...baseRoutes, ...frameworkLangRoutes]
+
+const routeMeta = {
+  '/': {
+    title: 'Programming Language & Framework Catalog — CodeSphere',
+    description:
+      'Explore programming languages and frameworks in one organized developer reference.',
+  },
+  '/Frameworks': {
+    title: 'All Frameworks by Language — CodeSphere',
+    description: 'Browse popular frameworks organized by programming language.',
+  },
+  '/TimeLine': {
+    title: 'History of Programming Languages — CodeSphere',
+    description: 'Interactive timeline of major programming languages and their origins.',
+  },
+  '/ml-roadmap': {
+    title: 'Machine Learning Roadmap — CodeSphere',
+    description: 'Step-by-step learning roadmap for machine learning engineers.',
+  },
+  '/ai-roadmap': {
+    title: 'AI Engineer Roadmap — CodeSphere',
+    description: 'A practical roadmap to become an AI engineer from fundamentals to deployment.',
+  },
+  '/swe-roadmap': {
+    title: 'Software Engineer Roadmap — CodeSphere',
+    description: 'Guided path through core software engineering skills and topics.',
+  },
+  '/developer-essential-skills': {
+    title: 'Developer Essential Skills — CodeSphere',
+    description: 'Key skills every modern developer should build for long-term growth.',
+  },
+  '/system-design': {
+    title: 'System Design Reference — CodeSphere',
+    description: 'Core system design concepts: scalability, caching, and distributed systems.',
+  },
+  '/design-patterns': {
+    title: 'Software Design Patterns — CodeSphere',
+    description: 'Reference for creational, structural, and behavioral design patterns.',
+  },
+  '/devops': {
+    title: 'DevOps & Infrastructure Guide — CodeSphere',
+    description: 'DevOps tools, CI/CD workflows, and infrastructure best practices.',
+  },
+  '/project-checklist': {
+    title: 'Project Checklist — CodeSphere',
+    description: 'Comprehensive checklist to plan, build, and ship software projects.',
+  },
+  '/design-principles': {
+    title: 'Design Principles — CodeSphere',
+    description: 'Essential software design principles for maintainable and scalable systems.',
+  },
+  '/design-styles': {
+    title: 'Design Styles Guide — CodeSphere',
+    description: 'Explore modern design styles and their practical use cases.',
+  },
+  '/motion-design': {
+    title: 'Motion Design Guide — CodeSphere',
+    description: 'Motion design principles, techniques, and implementation ideas.',
+  },
+  '/animations-guide': {
+    title: 'Animations Guide — CodeSphere',
+    description: 'Practical guide to UI and web animations for developers.',
+  },
+  '/civic-sense': {
+    title: 'Civic Sense Guide — CodeSphere',
+    description: 'Civic awareness and practical social responsibility insights.',
+  },
+  '/social-intelligence': {
+    title: 'Social Intelligence Guide — CodeSphere',
+    description: 'Develop communication, empathy, and interpersonal effectiveness.',
+  },
+  '/vibe-explorer': {
+    title: 'Vibe Explorer — CodeSphere',
+    description: 'Explore and discover coding vibes, genres, and creative themes.',
+  },
+}
+
+const escapeHtml = (value) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+const frameworkLangSlugMap = {
+  'c++': 'cpp',
+  'c#': 'csharp',
+}
+
+function toFrameworkSlug(lang) {
+  const normalized = lang.trim().toLowerCase()
+  return frameworkLangSlugMap[normalized] ?? normalized.replace(/[^a-z0-9]+/g, '-')
+}
+
+function routeToOutputPath(route) {
+  const [pathname, query] = route.split('?')
+  if (pathname === '/Frameworks' && query?.startsWith('lang=')) {
+    const lang = decodeURIComponent(query.slice(5))
+    return path.join(distDir, 'frameworks', toFrameworkSlug(lang), 'index.html')
+  }
+
+  if (pathname === '/') {
+    return templatePath
+  }
+
+  return path.join(distDir, pathname.replace(/^\//, ''), 'index.html')
+}
+
+function buildMetaTags(route) {
+  const [pathname, query] = route.split('?')
+  const baseMeta = routeMeta[pathname] ?? {
+    title: 'CodeSphere',
+    description: 'A developer reference for programming languages, frameworks, and architecture.',
+  }
+
+  if (pathname === '/Frameworks' && query?.startsWith('lang=')) {
+    const lang = decodeURIComponent(query.slice(5))
+    const escapedLang = escapeHtml(lang)
+    return {
+      title: `${escapedLang} Frameworks — CodeSphere`,
+      description: `Browse popular ${escapedLang} frameworks and libraries in a structured reference.`,
+      canonicalPath: `/frameworks/${toFrameworkSlug(lang)}`,
+    }
+  }
+
+  return {
+    ...baseMeta,
+    canonicalPath: pathname,
+  }
+}
+
+function buildHtmlWithMeta({ template, appHtml, title, description, canonicalPath }) {
+  const escapedTitle = escapeHtml(title)
+  const escapedDescription = escapeHtml(description)
+  const canonicalUrl = `https://codes-sphere.vercel.app${canonicalPath}`
+
+  const metaTags = `\n    <meta name="description" content="${escapedDescription}" />\n    <meta property="og:title" content="${escapedTitle}" />\n    <meta property="og:description" content="${escapedDescription}" />\n    <meta property="og:type" content="website" />\n    <meta property="og:url" content="${canonicalUrl}" />\n    <meta name="twitter:card" content="summary_large_image" />\n    <meta name="twitter:title" content="${escapedTitle}" />\n    <meta name="twitter:description" content="${escapedDescription}" />\n    <link rel="canonical" href="${canonicalUrl}" />\n  `
+
+  return template
+    .replace('<title>CodeSphere</title>', `<title>${escapedTitle}</title>`)
+    .replace('</head>', `${metaTags}</head>`)
+    .replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)
+}
+
+for (const route of routesToPrerender) {
+  const appHtml = await render(route)
+  const meta = buildMetaTags(route)
+  const renderedHtml = buildHtmlWithMeta({
+    template: templateHtml,
+    appHtml,
+    title: meta.title,
+    description: meta.description,
+    canonicalPath: meta.canonicalPath,
+  })
+
+  if (renderedHtml === templateHtml) {
+    throw new Error(`Failed to inject prerendered HTML into template for ${route}`)
+  }
+
+  const outputPath = routeToOutputPath(route)
+  await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  await fs.writeFile(outputPath, renderedHtml, 'utf-8')
+
+  console.log(`Pre-rendered ${route} -> ${path.relative(distDir, outputPath)}`)
+}
+
+async function generateSitemap(routes) {
+  const base = 'https://codes-sphere.vercel.app'
+  const today = new Date().toISOString().split('T')[0]
+
+  const canonicalPaths = new Set(
+    routes.map((route) => buildMetaTags(route).canonicalPath).filter(Boolean),
   )
 
-  if (hydratedHtml === templateHtml) {
-    throw new Error(`Failed to inject prerendered HTML into template for ${url}`)
-  }
+  const urls = [...canonicalPaths]
+    .map(
+      (urlPath) => `\n  <url>\n    <loc>${base}${urlPath}</loc>\n    <lastmod>${today}</lastmod>\n    <changefreq>${urlPath === '/' ? 'weekly' : 'monthly'}</changefreq>\n    <priority>${urlPath === '/' ? '1.0' : '0.8'}</priority>\n  </url>`,
+    )
+    .join('')
 
-  const outputPath =
-    url === '/'
-      ? templatePath
-      : path.join(distDir, url.replace(/^\//, ''), 'index.html')
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}\n</urlset>\n`
 
-  if (url !== '/') {
-    await fs.mkdir(path.dirname(outputPath), { recursive: true })
-  }
-
-  await fs.writeFile(outputPath, hydratedHtml, 'utf-8')
-  console.log(`Pre-rendered ${url} -> ${path.relative(distDir, outputPath)}`)
+  await fs.writeFile(path.join(distDir, 'sitemap.xml'), xml, 'utf-8')
+  console.log('Generated sitemap.xml')
 }
+
+await generateSitemap(routesToPrerender)

--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -26,7 +26,8 @@ import CopyPage from "./Components/CopyPage.jsx";
 
 const Layout = () => {
   const location = useLocation();
-  const hideFooter = location.pathname.startsWith("/Frameworks");
+  const lowerPath = location.pathname.toLowerCase();
+  const hideFooter = lowerPath.startsWith("/frameworks");
 
   return (
     <div className="max-w-full overflow-x-hidden">
@@ -37,6 +38,7 @@ const Layout = () => {
       <Routes>
         <Route path='/' element={<ProgrammingLanguages />} />
         <Route path='/Frameworks' element={<Frameworks />} />
+        <Route path='/frameworks/:langSlug' element={<Frameworks />} />
         <Route path='/TimeLine' element={<ProgrammingTimeline />} />
         <Route path='/ml-roadmap' element={<MachineLearningRoadmap />} />
         <Route path='/ai-roadmap' element={<AIEngineerRoadmap />} />

--- a/src/Components/Frameworks.jsx
+++ b/src/Components/Frameworks.jsx
@@ -1,17 +1,31 @@
 import { useEffect, useMemo } from "react";
 import Card from "./cards/Card";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router-dom";
 import useSEO from "./Hooks/useSEO";
 import LanguagesCatalog from "../Data/LanguagesCatalog.json";
 import { IoIosArrowBack } from "react-icons/io";
 
 
+
+const FRAMEWORK_SLUG_MAP = {
+  cpp: "C++",
+  csharp: "C#",
+}
+
+const normalizeFrameworkSlug = (langSlug = "") => {
+  if (!langSlug) return null
+  return FRAMEWORK_SLUG_MAP[langSlug.toLowerCase()] ?? langSlug
+}
+
 const Frameworks = () => {
   const location = useLocation();
+  const { langSlug } = useParams();
   const { Frameworks: stateFrameworks = [] } = location.state || {};
 
   const langFromQuery = new URLSearchParams(location.search).get("lang");
-  const normalizedLang = langFromQuery?.toLowerCase();
+  const langFromSlug = normalizeFrameworkSlug(langSlug);
+  const activeLang = langFromQuery || langFromSlug;
+  const normalizedLang = activeLang?.toLowerCase();
 
   const languageDetails = useMemo(() => {
     if (!normalizedLang) return null;
@@ -123,8 +137,10 @@ const Frameworks = () => {
   ]);
 
   const canonicalUrl = languageDetails
-    ? `https://codes-sphere.vercel.app/Frameworks?lang=${encodeURIComponent(
-      languageDetails.Language
+    ? `https://codes-sphere.vercel.app/frameworks/${encodeURIComponent(
+      languageDetails.Language.toLowerCase()
+        .replace("c++", "cpp")
+        .replace("c#", "csharp")
     )}`
     : "https://codes-sphere.vercel.app/Frameworks";
 

--- a/src/Components/ProjectChecklist.jsx
+++ b/src/Components/ProjectChecklist.jsx
@@ -9,18 +9,23 @@ import useSEO from "./Hooks/useSEO";
 import checklistData from "../Data/ProjectChecklist.json";
 
 const ProjectChecklist = () => {
+  const canUseStorage = typeof window !== "undefined" && typeof localStorage !== "undefined";
+
   // Persistence states
   const [selectedAddons, setSelectedAddons] = useState(() => {
+    if (!canUseStorage) return [];
     const saved = localStorage.getItem("codesphere_checklist_addons");
     return saved ? JSON.parse(saved) : [];
   });
 
   const [checkedTaskIds, setCheckedTaskIds] = useState(() => {
+    if (!canUseStorage) return [];
     const saved = localStorage.getItem("codesphere_checklist_checked");
     return saved ? JSON.parse(saved) : [];
   });
 
   const [hasShownWarning, setHasShownWarning] = useState(() => {
+    if (!canUseStorage) return false;
     return localStorage.getItem("codesphere_checklist_warning_shown") === "true";
   });
 
@@ -52,18 +57,21 @@ const ProjectChecklist = () => {
 
   // Persistence effects
   useEffect(() => {
+    if (!canUseStorage) return;
     localStorage.setItem("codesphere_checklist_addons", JSON.stringify(selectedAddons));
-  }, [selectedAddons]);
+  }, [canUseStorage, selectedAddons]);
 
   useEffect(() => {
+    if (!canUseStorage) return;
     localStorage.setItem("codesphere_checklist_checked", JSON.stringify(checkedTaskIds));
-  }, [checkedTaskIds]);
+  }, [canUseStorage, checkedTaskIds]);
 
   useEffect(() => {
+    if (!canUseStorage) return;
     if (hasShownWarning) {
       localStorage.setItem("codesphere_checklist_warning_shown", "true");
     }
-  }, [hasShownWarning]);
+  }, [canUseStorage, hasShownWarning]);
 
   const toggleAddon = (addonKey) => {
     setSelectedAddons((prev) =>


### PR DESCRIPTION
### Motivation
- Improve prerendered pages with per-route SEO metadata and canonical URLs to boost discoverability and avoid duplicate content.
- Pre-generate language-specific framework pages and a sitemap so indexed pages are accessible via semantic paths (e.g. `/frameworks/cpp`).
- Support framework routes in the client router and handle edge cases for server-side and static rendering, including safe use of `localStorage`.

### Description
- Reworked `scripts/prerender.js` to build a `routesToPrerender` list, inject route-specific `<title>`/meta/OG/Twitter tags, generate canonical URLs, output language-aware file paths, and write a `sitemap.xml` for the site.
- Added language list and slug mapping logic (`frameworkLangs`, `frameworkLangSlugMap`, `toFrameworkSlug`, `routeToOutputPath`, `buildMetaTags`, and `generateSitemap`) and ensured HTML injection via `buildHtmlWithMeta` before writing files.
- Updated routing in `src/AppRoutes.jsx` to treat framework paths case-insensitively and added a new route `'/frameworks/:langSlug'` to support slug-based navigation and hide the footer appropriately.
- Enhanced `src/Components/Frameworks.jsx` to accept `langSlug` from URL params, normalize special language slugs (`cpp`, `csharp`) back to display names, derive active language from either query or slug, and produce canonical URLs that use the slug path.
- Hardened `src/Components/ProjectChecklist.jsx` against non-browser environments by gating `localStorage` usage with a `canUseStorage` check and adjusting persistence `useEffect` dependencies to avoid SSR errors.

### Testing
- Built the project with `npm run build` and executed the prerender script via `node scripts/prerender.js`, which completed and produced the expected prerendered HTML files and `sitemap.xml` without errors.
- Verified the dev router picks up `'/frameworks/:langSlug'` and that the footer hide logic works for `/Frameworks` and `/frameworks/*` variants during manual local smoke testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f313cb6594832ab348790cc991bee2)